### PR TITLE
Update web-client-crazyEights.js

### DIFF
--- a/public/js/web-client-crazyEights.js
+++ b/public/js/web-client-crazyEights.js
@@ -51,6 +51,8 @@ $(document).ready(() =>{
       success: result => {
         if (result.done){
           setLastCard(card[0]+card[1]);
+          $('.player-cards .new-cards').empty();
+          $('.player-cards').width($('.player-cards').width(0));
           $('#play_game').toggleClass('hidden');
           success();
 


### PR DESCRIPTION
Deletes current player's hand so that in the next turn only the new one is displayed.
